### PR TITLE
feat: add grading strategy field in problem editor

### DIFF
--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -166,9 +166,9 @@ export const scoringCardHooks = (scoring, updateSettings, defaultValue) => {
     updateSettings({ scoring: { ...scoring, weight } });
   };
 
-  const handleGradingStrategyChange = (event) => {
+  const handleGradingMethodChange = (event) => {
     const { value } = event.target;
-    updateSettings({ scoring: { ...scoring, gradingStrategy: value } });
+    updateSettings({ scoring: { ...scoring, gradingMethod: value } });
   };
 
   return {
@@ -177,7 +177,7 @@ export const scoringCardHooks = (scoring, updateSettings, defaultValue) => {
     handleMaxAttemptChange,
     handleOnChange,
     handleWeightChange,
-    handleGradingStrategyChange,
+    handleGradingMethodChange,
   };
 };
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.js
@@ -166,12 +166,18 @@ export const scoringCardHooks = (scoring, updateSettings, defaultValue) => {
     updateSettings({ scoring: { ...scoring, weight } });
   };
 
+  const handleGradingStrategyChange = (event) => {
+    const { value } = event.target;
+    updateSettings({ scoring: { ...scoring, gradingStrategy: value } });
+  };
+
   return {
     attemptDisplayValue,
     handleUnlimitedChange,
     handleMaxAttemptChange,
     handleOnChange,
     handleWeightChange,
+    handleGradingStrategyChange,
   };
 };
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -146,7 +146,7 @@ describe('Problem settings hooks', () => {
         unlimited: false,
         number: 5,
       },
-      gradingStrategy: 'last_attempt',
+      gradingStrategy: 'last_score',
     };
     const defaultValue = 1;
     test('test scoringCardHooks initializes display value when attempts.number is null', () => {
@@ -270,7 +270,7 @@ describe('Problem settings hooks', () => {
       expect(updateSettings).toHaveBeenCalledWith({ scoring: { ...scoring, weight: parseFloat(value) } });
     });
     test('test handleGradingStrategyChange', () => {
-      const value = 'first_attempt';
+      const value = 'first_score';
       output.handleGradingStrategyChange({ target: { value } });
       expect(updateSettings).toHaveBeenCalledWith({ scoring: { ...scoring, gradingStrategy: value } });
     });

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -146,7 +146,7 @@ describe('Problem settings hooks', () => {
         unlimited: false,
         number: 5,
       },
-      gradingStrategy: 'last_score',
+      gradingMethod: 'last_score',
     };
     const defaultValue = 1;
     test('test scoringCardHooks initializes display value when attempts.number is null', () => {
@@ -269,10 +269,10 @@ describe('Problem settings hooks', () => {
       output.handleWeightChange({ target: { value } });
       expect(updateSettings).toHaveBeenCalledWith({ scoring: { ...scoring, weight: parseFloat(value) } });
     });
-    test('test handleGradingStrategyChange', () => {
+    test('test handleGradingMethodChange', () => {
       const value = 'first_score';
-      output.handleGradingStrategyChange({ target: { value } });
-      expect(updateSettings).toHaveBeenCalledWith({ scoring: { ...scoring, gradingStrategy: value } });
+      output.handleGradingMethodChange({ target: { value } });
+      expect(updateSettings).toHaveBeenCalledWith({ scoring: { ...scoring, gradingMethod: value } });
     });
   });
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/hooks.test.js
@@ -146,6 +146,7 @@ describe('Problem settings hooks', () => {
         unlimited: false,
         number: 5,
       },
+      gradingStrategy: 'last_attempt',
     };
     const defaultValue = 1;
     test('test scoringCardHooks initializes display value when attempts.number is null', () => {
@@ -267,6 +268,11 @@ describe('Problem settings hooks', () => {
       const value = 2;
       output.handleWeightChange({ target: { value } });
       expect(updateSettings).toHaveBeenCalledWith({ scoring: { ...scoring, weight: parseFloat(value) } });
+    });
+    test('test handleGradingStrategyChange', () => {
+      const value = 'first_attempt';
+      output.handleGradingStrategyChange({ target: { value } });
+      expect(updateSettings).toHaveBeenCalledWith({ scoring: { ...scoring, gradingStrategy: value } });
     });
   });
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
@@ -171,7 +171,7 @@ SettingsWidget.propTypes = {
     showanswer: PropTypes.string,
     showResetButton: PropTypes.bool,
     rerandomize: PropTypes.string,
-    gradingStrategy: PropTypes.string,
+    gradingMethod: PropTypes.string,
   }).isRequired,
   // eslint-disable-next-line
   settings: PropTypes.any.isRequired,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
@@ -169,8 +169,9 @@ SettingsWidget.propTypes = {
   defaultSettings: PropTypes.shape({
     maxAttempts: PropTypes.number,
     showanswer: PropTypes.string,
-    showResetButton: PropTypes.bool,
     rerandomize: PropTypes.string,
+    showReseButton: PropTypes.bool,
+    gradingStrategy: PropTypes.string,
   }).isRequired,
   // eslint-disable-next-line
   settings: PropTypes.any.isRequired,

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.jsx
@@ -169,8 +169,8 @@ SettingsWidget.propTypes = {
   defaultSettings: PropTypes.shape({
     maxAttempts: PropTypes.number,
     showanswer: PropTypes.string,
+    showResetButton: PropTypes.bool,
     rerandomize: PropTypes.string,
-    showReseButton: PropTypes.bool,
     gradingStrategy: PropTypes.string,
   }).isRequired,
   // eslint-disable-next-line

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.test.jsx
@@ -28,6 +28,7 @@ describe('SettingsWidget', () => {
       maxAttempts: 2,
       showanswer: 'finished',
       showResetButton: false,
+      gradingStrategy: 'last_attempt',
     },
   };
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.test.jsx
@@ -28,7 +28,7 @@ describe('SettingsWidget', () => {
       maxAttempts: 2,
       showanswer: 'finished',
       showResetButton: false,
-      gradingStrategy: 'last_attempt',
+      gradingStrategy: 'last_score',
     },
   };
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/index.test.jsx
@@ -28,7 +28,7 @@ describe('SettingsWidget', () => {
       maxAttempts: 2,
       showanswer: 'finished',
       showResetButton: false,
-      gradingStrategy: 'last_score',
+      gradingMethod: 'last_score',
     },
   };
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
@@ -82,6 +82,11 @@ const messages = defineMessages({
     defaultMessage: 'Points',
     description: 'Scoring weight input label',
   },
+  scoringGradingStrategyInputLabel: {
+    id: 'authoring.problemeditor.settings.scoring.gradingStrategy.inputLabel',
+    defaultMessage: 'Grading Strategy',
+    description: 'Grading strategy input label',
+  },
   unlimitedAttemptsSummary: {
     id: 'authoring.problemeditor.settings.scoring.unlimited',
     defaultMessage: 'Unlimited attempts',
@@ -104,7 +109,7 @@ const messages = defineMessages({
   },
   scoringSettingsLabel: {
     id: 'authoring.problemeditor.settings.scoring.label',
-    defaultMessage: 'Specify point weight and the number of answer attempts',
+    defaultMessage: 'Specify grading strategy, point weight and the number of answer attempts',
     description: 'Descriptive text for scoring settings',
   },
   attemptsHint: {
@@ -116,6 +121,11 @@ const messages = defineMessages({
     id: 'authoring.problemeditor.settings.scoring.weight.hint',
     defaultMessage: 'If a value is not set, the problem is worth one point',
     description: 'Summary text for scoring weight',
+  },
+  gradingStrategyHint: {
+    id: 'authoring.problemeditor.settings.scoring.gradingStrategy.hint',
+    defaultMessage: 'Define the grading strategy for this problem. By default the last attempt made by the student is taken.',
+    description: 'Summary text for scoring grading strategy',
   },
   showAnswerSettingsTitle: {
     id: 'authoring.problemeditor.settings.showAnswer.title',

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
@@ -82,15 +82,15 @@ const messages = defineMessages({
     defaultMessage: 'Points',
     description: 'Scoring weight input label',
   },
-  scoringGradingStrategyInputLabel: {
-    id: 'authoring.problemeditor.settings.scoring.gradingStrategy.inputLabel',
-    defaultMessage: 'Grading Strategy',
-    description: 'Grading strategy input label',
+  scoringGradingMethodInputLabel: {
+    id: 'authoring.problemeditor.settings.scoring.gradingMethod.inputLabel',
+    defaultMessage: 'Grading Method',
+    description: 'Grading method input label',
   },
-  gradingStrategySummary: {
-    id: 'authoring.problemeditor.settings.scoring.gradingStrategy',
-    defaultMessage: '{gradingStrategy}',
-    description: 'Summary text for scoring grading strategy',
+  gradingMethodSummary: {
+    id: 'authoring.problemeditor.settings.scoring.gradingMethod',
+    defaultMessage: '{gradingMethod}',
+    description: 'Summary text for scoring grading method',
   },
   unlimitedAttemptsSummary: {
     id: 'authoring.problemeditor.settings.scoring.unlimited',
@@ -114,7 +114,7 @@ const messages = defineMessages({
   },
   scoringSettingsLabel: {
     id: 'authoring.problemeditor.settings.scoring.label',
-    defaultMessage: 'Specify grading strategy, point weight and the number of answer attempts',
+    defaultMessage: 'Specify grading method, point weight and the number of answer attempts',
     description: 'Descriptive text for scoring settings',
   },
   attemptsHint: {
@@ -127,10 +127,10 @@ const messages = defineMessages({
     defaultMessage: 'If a value is not set, the problem is worth one point',
     description: 'Summary text for scoring weight',
   },
-  gradingStrategyHint: {
-    id: 'authoring.problemeditor.settings.scoring.gradingStrategy.hint',
-    defaultMessage: 'Define the grading strategy for this problem. By default, it is the score of the last submission made by the student.',
-    description: 'Summary text for scoring grading strategy',
+  gradingMethodHint: {
+    id: 'authoring.problemeditor.settings.scoring.gradingMethod.hint',
+    defaultMessage: 'Define the grading method for this problem. By default, it is the score of the last submission made by the student.',
+    description: 'Summary text for scoring grading method',
   },
   showAnswerSettingsTitle: {
     id: 'authoring.problemeditor.settings.showAnswer.title',

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
@@ -87,6 +87,11 @@ const messages = defineMessages({
     defaultMessage: 'Grading Strategy',
     description: 'Grading strategy input label',
   },
+  gradingStrategySummary: {
+    id: 'authoring.problemeditor.settings.scoring.gradingStrategy',
+    defaultMessage: '{gradingStrategy}',
+    description: 'Summary text for scoring grading strategy',
+  },
   unlimitedAttemptsSummary: {
     id: 'authoring.problemeditor.settings.scoring.unlimited',
     defaultMessage: 'Unlimited attempts',

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
@@ -129,7 +129,7 @@ const messages = defineMessages({
   },
   gradingStrategyHint: {
     id: 'authoring.problemeditor.settings.scoring.gradingStrategy.hint',
-    defaultMessage: 'Define the grading strategy for this problem. By default the last attempt made by the student is taken.',
+    defaultMessage: 'Define the grading strategy for this problem. By default the last score made by the student is taken.',
     description: 'Summary text for scoring grading strategy',
   },
   showAnswerSettingsTitle: {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/messages.js
@@ -129,7 +129,7 @@ const messages = defineMessages({
   },
   gradingStrategyHint: {
     id: 'authoring.problemeditor.settings.scoring.gradingStrategy.hint',
-    defaultMessage: 'Define the grading strategy for this problem. By default the last score made by the student is taken.',
+    defaultMessage: 'Define the grading strategy for this problem. By default, it is the score of the last submission made by the student.',
     description: 'Summary text for scoring grading strategy',
   },
   showAnswerSettingsTitle: {

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
@@ -24,11 +24,12 @@ export const ScoringCard = ({
     handleUnlimitedChange,
     handleMaxAttemptChange,
     handleWeightChange,
+    handleGradingStrategyChange,
     handleOnChange,
     attemptDisplayValue,
   } = scoringCardHooks(scoring, updateSettings, defaultValue);
 
-  const getScoringSummary = (weight, attempts, unlimited) => {
+  const getScoringSummary = (weight, attempts, unlimited, gradingStrategy) => {
     let summary = intl.formatMessage(messages.weightSummary, { weight });
     summary += ` ${String.fromCharCode(183)} `;
     summary += unlimited
@@ -46,6 +47,17 @@ export const ScoringCard = ({
       <div className="mb-4">
         <FormattedMessage {...messages.scoringSettingsLabel} />
       </div>
+      <Form.Group>
+        <Form.Control
+          as="select"
+          value={scoring.gradingStrategy}
+          onChange={handleGradingStrategyChange}
+          floatingLabel={intl.formatMessage(messages.scoringGradingStrategyInputLabel)}
+        />
+        <Form.Control.Feedback>
+          <FormattedMessage {...messages.gradingStrategyHint} />
+        </Form.Control.Feedback>
+      </Form.Group>
       <Form.Group>
         <Form.Control
           type="number"

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
@@ -8,7 +8,7 @@ import { selectors } from '../../../../../../data/redux';
 import SettingsOption from '../SettingsOption';
 import messages from '../messages';
 import { scoringCardHooks } from '../hooks';
-import { GradingStrategy, GradingStrategyKeys } from '../../../../../../data/constants/problem';
+import { GradingMethod, GradingMethodKeys } from '../../../../../../data/constants/problem';
 
 export const ScoringCard = ({
   scoring,
@@ -25,20 +25,20 @@ export const ScoringCard = ({
     handleUnlimitedChange,
     handleMaxAttemptChange,
     handleWeightChange,
-    handleGradingStrategyChange,
+    handleGradingMethodChange,
     handleOnChange,
     attemptDisplayValue,
   } = scoringCardHooks(scoring, updateSettings, defaultValue);
 
-  const getScoringSummary = (weight, attempts, unlimited, gradingStrategy) => {
+  const getScoringSummary = (weight, attempts, unlimited, gradingMethod) => {
     let summary = intl.formatMessage(messages.weightSummary, { weight });
     summary += ` ${String.fromCharCode(183)} `;
     summary += unlimited
       ? intl.formatMessage(messages.unlimitedAttemptsSummary)
       : intl.formatMessage(messages.attemptsSummary, { attempts: attempts || defaultValue });
     summary += ` ${String.fromCharCode(183)} `;
-    summary += intl.formatMessage(messages.gradingStrategySummary, {
-      gradingStrategy: intl.formatMessage(GradingStrategy[gradingStrategy]),
+    summary += intl.formatMessage(messages.gradingMethodSummary, {
+      gradingMethod: intl.formatMessage(GradingMethod[gradingMethod]),
     });
     return summary;
   };
@@ -51,7 +51,7 @@ export const ScoringCard = ({
           scoring.weight,
           scoring.attempts.number,
           scoring.attempts.unlimited,
-          scoring.gradingStrategy,
+          scoring.gradingMethod,
         )
       }
       className="scoringCard"
@@ -62,16 +62,16 @@ export const ScoringCard = ({
       <Form.Group>
         <Form.Control
           as="select"
-          value={scoring.gradingStrategy}
-          onChange={handleGradingStrategyChange}
-          floatingLabel={intl.formatMessage(messages.scoringGradingStrategyInputLabel)}
+          value={scoring.gradingMethod}
+          onChange={handleGradingMethodChange}
+          floatingLabel={intl.formatMessage(messages.scoringGradingMethodInputLabel)}
         >
-          {Object.values(GradingStrategyKeys).map((gradingStrategy) => {
-            const optionDisplayName = GradingStrategy[gradingStrategy];
+          {Object.values(GradingMethodKeys).map((gradingMethod) => {
+            const optionDisplayName = GradingMethod[gradingMethod];
             return (
               <option
-                key={gradingStrategy}
-                value={gradingStrategy}
+                key={gradingMethod}
+                value={gradingMethod}
               >
                 {intl.formatMessage(optionDisplayName)}
               </option>
@@ -79,7 +79,7 @@ export const ScoringCard = ({
           })}
         </Form.Control>
         <Form.Control.Feedback>
-          <FormattedMessage {...messages.gradingStrategyHint} />
+          <FormattedMessage {...messages.gradingMethodHint} />
         </Form.Control.Feedback>
       </Form.Group>
       <Form.Group>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
@@ -37,14 +37,23 @@ export const ScoringCard = ({
       ? intl.formatMessage(messages.unlimitedAttemptsSummary)
       : intl.formatMessage(messages.attemptsSummary, { attempts: attempts || defaultValue });
     summary += ` ${String.fromCharCode(183)} `;
-    summary += intl.formatMessage(messages.gradingStrategySummary, { gradingStrategy: intl.formatMessage(GradingStrategy[gradingStrategy]) });
+    summary += intl.formatMessage(messages.gradingStrategySummary, {
+      gradingStrategy: intl.formatMessage(GradingStrategy[gradingStrategy]),
+    });
     return summary;
   };
 
   return (
     <SettingsOption
       title={intl.formatMessage(messages.scoringSettingsTitle)}
-      summary={getScoringSummary(scoring.weight, scoring.attempts.number, scoring.attempts.unlimited, scoring.gradingStrategy)}
+      summary={
+        getScoringSummary(
+          scoring.weight,
+          scoring.attempts.number,
+          scoring.attempts.unlimited,
+          scoring.gradingStrategy,
+        )
+      }
       className="scoringCard"
     >
       <div className="mb-4">

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
@@ -8,6 +8,7 @@ import { selectors } from '../../../../../../data/redux';
 import SettingsOption from '../SettingsOption';
 import messages from '../messages';
 import { scoringCardHooks } from '../hooks';
+import { GradingStrategy, GradingStrategyKeys } from '../../../../../../data/constants/problem';
 
 export const ScoringCard = ({
   scoring,
@@ -35,13 +36,15 @@ export const ScoringCard = ({
     summary += unlimited
       ? intl.formatMessage(messages.unlimitedAttemptsSummary)
       : intl.formatMessage(messages.attemptsSummary, { attempts: attempts || defaultValue });
+    summary += ` ${String.fromCharCode(183)} `;
+    summary += intl.formatMessage(messages.gradingStrategySummary, { gradingStrategy: intl.formatMessage(GradingStrategy[gradingStrategy]) });
     return summary;
   };
 
   return (
     <SettingsOption
       title={intl.formatMessage(messages.scoringSettingsTitle)}
-      summary={getScoringSummary(scoring.weight, scoring.attempts.number, scoring.attempts.unlimited)}
+      summary={getScoringSummary(scoring.weight, scoring.attempts.number, scoring.attempts.unlimited, scoring.gradingStrategy)}
       className="scoringCard"
     >
       <div className="mb-4">
@@ -53,7 +56,22 @@ export const ScoringCard = ({
           value={scoring.gradingStrategy}
           onChange={handleGradingStrategyChange}
           floatingLabel={intl.formatMessage(messages.scoringGradingStrategyInputLabel)}
-        />
+        >
+          {Object.values(GradingStrategyKeys).map((gradingStrategy) => {
+            let optionDisplayName = GradingStrategy[gradingStrategy];
+            if (gradingStrategy === defaultValue) {
+              optionDisplayName = { ...optionDisplayName, defaultMessage: `${optionDisplayName.defaultMessage} (Default)` };
+            }
+            return (
+              <option
+                key={gradingStrategy}
+                value={gradingStrategy}
+              >
+                {intl.formatMessage(optionDisplayName)}
+              </option>
+            );
+          })}
+        </Form.Control>
         <Form.Control.Feedback>
           <FormattedMessage {...messages.gradingStrategyHint} />
         </Form.Control.Feedback>

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.jsx
@@ -67,10 +67,7 @@ export const ScoringCard = ({
           floatingLabel={intl.formatMessage(messages.scoringGradingStrategyInputLabel)}
         >
           {Object.values(GradingStrategyKeys).map((gradingStrategy) => {
-            let optionDisplayName = GradingStrategy[gradingStrategy];
-            if (gradingStrategy === defaultValue) {
-              optionDisplayName = { ...optionDisplayName, defaultMessage: `${optionDisplayName.defaultMessage} (Default)` };
-            }
+            const optionDisplayName = GradingStrategy[gradingStrategy];
             return (
               <option
                 key={gradingStrategy}

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.test.jsx
@@ -15,7 +15,7 @@ describe('ScoringCard', () => {
       unlimited: false,
       number: 5,
     },
-    gradingStrategy: 'last_score',
+    gradingMethod: 'last_score',
     updateSettings: jest.fn().mockName('args.updateSettings'),
     intl: { formatMessage },
   };
@@ -30,7 +30,7 @@ describe('ScoringCard', () => {
     handleMaxAttemptChange: jest.fn().mockName('scoringCardHooks.handleMaxAttemptChange'),
     handleWeightChange: jest.fn().mockName('scoringCardHooks.handleWeightChange'),
     handleOnChange: jest.fn().mockName('scoringCardHooks.handleOnChange'),
-    handleGradingStrategyChange: jest.fn().mockName('scoringCardHooks.handleGradingStrategyChange'),
+    handleGradingMethodChange: jest.fn().mockName('scoringCardHooks.handleGradingMethodChange'),
     local: 5,
   };
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.test.jsx
@@ -15,6 +15,7 @@ describe('ScoringCard', () => {
       unlimited: false,
       number: 5,
     },
+    gradingStrategy: 'last_attempt',
     updateSettings: jest.fn().mockName('args.updateSettings'),
     intl: { formatMessage },
   };
@@ -29,6 +30,7 @@ describe('ScoringCard', () => {
     handleMaxAttemptChange: jest.fn().mockName('scoringCardHooks.handleMaxAttemptChange'),
     handleWeightChange: jest.fn().mockName('scoringCardHooks.handleWeightChange'),
     handleOnChange: jest.fn().mockName('scoringCardHooks.handleOnChange'),
+    handleGradingStrategyChange: jest.fn().mockName('scoringCardHooks.handleGradingStrategyChange'),
     local: 5,
   };
 

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.test.jsx
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/ScoringCard.test.jsx
@@ -15,7 +15,7 @@ describe('ScoringCard', () => {
       unlimited: false,
       number: 5,
     },
-    gradingStrategy: 'last_attempt',
+    gradingStrategy: 'last_score',
     updateSettings: jest.fn().mockName('args.updateSettings'),
     intl: { formatMessage },
   };

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ScoringCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ScoringCard.test.jsx.snap
@@ -5,18 +5,58 @@ exports[`ScoringCard snapshot snapshot: scoring setting card 1`] = `
   className="scoringCard"
   extraSections={Array []}
   hasExpandableTextArea={false}
-  summary="{weight, plural, =0 {Ungraded} other {# points}} · {attempts, plural, =1 {# attempt} other {# attempts}}"
+  summary="{weight, plural, =0 {Ungraded} other {# points}} · {attempts, plural, =1 {# attempt} other {# attempts}} · Last Score"
   title="Scoring"
 >
   <div
     className="mb-4"
   >
     <FormattedMessage
-      defaultMessage="Specify point weight and the number of answer attempts"
+      defaultMessage="Specify grading strategy, point weight and the number of answer attempts"
       description="Descriptive text for scoring settings"
       id="authoring.problemeditor.settings.scoring.label"
     />
   </div>
+  <Form.Group>
+    <Form.Control
+      as="select"
+      floatingLabel="Grading Strategy"
+      onChange={[MockFunction scoringCardHooks.handleGradingStrategyChange]}
+      value="last_score"
+    >
+      <option
+        key="last_score"
+        value="last_score"
+      >
+        Last Score
+      </option>
+      <option
+        key="highest_score"
+        value="highest_score"
+      >
+        Highest Score
+      </option>
+      <option
+        key="average_score"
+        value="average_score"
+      >
+        Average Score
+      </option>
+      <option
+        key="first_score"
+        value="first_score"
+      >
+        First Score
+      </option>
+    </Form.Control>
+    <Form.Control.Feedback>
+      <FormattedMessage
+        defaultMessage="Define the grading strategy for this problem. By default, it is the score of the last submission made by the student."
+        description="Summary text for scoring grading strategy"
+        id="authoring.problemeditor.settings.scoring.gradingStrategy.hint"
+      />
+    </Form.Control.Feedback>
+  </Form.Group>
   <Form.Group>
     <Form.Control
       floatingLabel="Points"
@@ -80,18 +120,58 @@ exports[`ScoringCard snapshot snapshot: scoring setting card max attempts 1`] = 
   className="scoringCard"
   extraSections={Array []}
   hasExpandableTextArea={false}
-  summary="{weight, plural, =0 {Ungraded} other {# points}} · Unlimited attempts"
+  summary="{weight, plural, =0 {Ungraded} other {# points}} · Unlimited attempts · Last Score"
   title="Scoring"
 >
   <div
     className="mb-4"
   >
     <FormattedMessage
-      defaultMessage="Specify point weight and the number of answer attempts"
+      defaultMessage="Specify grading strategy, point weight and the number of answer attempts"
       description="Descriptive text for scoring settings"
       id="authoring.problemeditor.settings.scoring.label"
     />
   </div>
+  <Form.Group>
+    <Form.Control
+      as="select"
+      floatingLabel="Grading Strategy"
+      onChange={[MockFunction scoringCardHooks.handleGradingStrategyChange]}
+      value="last_score"
+    >
+      <option
+        key="last_score"
+        value="last_score"
+      >
+        Last Score
+      </option>
+      <option
+        key="highest_score"
+        value="highest_score"
+      >
+        Highest Score
+      </option>
+      <option
+        key="average_score"
+        value="average_score"
+      >
+        Average Score
+      </option>
+      <option
+        key="first_score"
+        value="first_score"
+      >
+        First Score
+      </option>
+    </Form.Control>
+    <Form.Control.Feedback>
+      <FormattedMessage
+        defaultMessage="Define the grading strategy for this problem. By default, it is the score of the last submission made by the student."
+        description="Summary text for scoring grading strategy"
+        id="authoring.problemeditor.settings.scoring.gradingStrategy.hint"
+      />
+    </Form.Control.Feedback>
+  </Form.Group>
   <Form.Group>
     <Form.Control
       floatingLabel="Points"
@@ -155,18 +235,58 @@ exports[`ScoringCard snapshot snapshot: scoring setting card zero zero weight 1`
   className="scoringCard"
   extraSections={Array []}
   hasExpandableTextArea={false}
-  summary="{weight, plural, =0 {Ungraded} other {# points}} · {attempts, plural, =1 {# attempt} other {# attempts}}"
+  summary="{weight, plural, =0 {Ungraded} other {# points}} · {attempts, plural, =1 {# attempt} other {# attempts}} · Last Score"
   title="Scoring"
 >
   <div
     className="mb-4"
   >
     <FormattedMessage
-      defaultMessage="Specify point weight and the number of answer attempts"
+      defaultMessage="Specify grading strategy, point weight and the number of answer attempts"
       description="Descriptive text for scoring settings"
       id="authoring.problemeditor.settings.scoring.label"
     />
   </div>
+  <Form.Group>
+    <Form.Control
+      as="select"
+      floatingLabel="Grading Strategy"
+      onChange={[MockFunction scoringCardHooks.handleGradingStrategyChange]}
+      value="last_score"
+    >
+      <option
+        key="last_score"
+        value="last_score"
+      >
+        Last Score
+      </option>
+      <option
+        key="highest_score"
+        value="highest_score"
+      >
+        Highest Score
+      </option>
+      <option
+        key="average_score"
+        value="average_score"
+      >
+        Average Score
+      </option>
+      <option
+        key="first_score"
+        value="first_score"
+      >
+        First Score
+      </option>
+    </Form.Control>
+    <Form.Control.Feedback>
+      <FormattedMessage
+        defaultMessage="Define the grading strategy for this problem. By default, it is the score of the last submission made by the student."
+        description="Summary text for scoring grading strategy"
+        id="authoring.problemeditor.settings.scoring.gradingStrategy.hint"
+      />
+    </Form.Control.Feedback>
+  </Form.Group>
   <Form.Group>
     <Form.Control
       floatingLabel="Points"

--- a/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ScoringCard.test.jsx.snap
+++ b/src/editors/containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/__snapshots__/ScoringCard.test.jsx.snap
@@ -12,7 +12,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card 1`] = `
     className="mb-4"
   >
     <FormattedMessage
-      defaultMessage="Specify grading strategy, point weight and the number of answer attempts"
+      defaultMessage="Specify grading method, point weight and the number of answer attempts"
       description="Descriptive text for scoring settings"
       id="authoring.problemeditor.settings.scoring.label"
     />
@@ -20,8 +20,8 @@ exports[`ScoringCard snapshot snapshot: scoring setting card 1`] = `
   <Form.Group>
     <Form.Control
       as="select"
-      floatingLabel="Grading Strategy"
-      onChange={[MockFunction scoringCardHooks.handleGradingStrategyChange]}
+      floatingLabel="Grading Method"
+      onChange={[MockFunction scoringCardHooks.handleGradingMethodChange]}
       value="last_score"
     >
       <option
@@ -51,9 +51,9 @@ exports[`ScoringCard snapshot snapshot: scoring setting card 1`] = `
     </Form.Control>
     <Form.Control.Feedback>
       <FormattedMessage
-        defaultMessage="Define the grading strategy for this problem. By default, it is the score of the last submission made by the student."
-        description="Summary text for scoring grading strategy"
-        id="authoring.problemeditor.settings.scoring.gradingStrategy.hint"
+        defaultMessage="Define the grading method for this problem. By default, it is the score of the last submission made by the student."
+        description="Summary text for scoring grading method"
+        id="authoring.problemeditor.settings.scoring.gradingMethod.hint"
       />
     </Form.Control.Feedback>
   </Form.Group>
@@ -127,7 +127,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card max attempts 1`] = 
     className="mb-4"
   >
     <FormattedMessage
-      defaultMessage="Specify grading strategy, point weight and the number of answer attempts"
+      defaultMessage="Specify grading method, point weight and the number of answer attempts"
       description="Descriptive text for scoring settings"
       id="authoring.problemeditor.settings.scoring.label"
     />
@@ -135,8 +135,8 @@ exports[`ScoringCard snapshot snapshot: scoring setting card max attempts 1`] = 
   <Form.Group>
     <Form.Control
       as="select"
-      floatingLabel="Grading Strategy"
-      onChange={[MockFunction scoringCardHooks.handleGradingStrategyChange]}
+      floatingLabel="Grading Method"
+      onChange={[MockFunction scoringCardHooks.handleGradingMethodChange]}
       value="last_score"
     >
       <option
@@ -166,9 +166,9 @@ exports[`ScoringCard snapshot snapshot: scoring setting card max attempts 1`] = 
     </Form.Control>
     <Form.Control.Feedback>
       <FormattedMessage
-        defaultMessage="Define the grading strategy for this problem. By default, it is the score of the last submission made by the student."
-        description="Summary text for scoring grading strategy"
-        id="authoring.problemeditor.settings.scoring.gradingStrategy.hint"
+        defaultMessage="Define the grading method for this problem. By default, it is the score of the last submission made by the student."
+        description="Summary text for scoring grading method"
+        id="authoring.problemeditor.settings.scoring.gradingMethod.hint"
       />
     </Form.Control.Feedback>
   </Form.Group>
@@ -242,7 +242,7 @@ exports[`ScoringCard snapshot snapshot: scoring setting card zero zero weight 1`
     className="mb-4"
   >
     <FormattedMessage
-      defaultMessage="Specify grading strategy, point weight and the number of answer attempts"
+      defaultMessage="Specify grading method, point weight and the number of answer attempts"
       description="Descriptive text for scoring settings"
       id="authoring.problemeditor.settings.scoring.label"
     />
@@ -250,8 +250,8 @@ exports[`ScoringCard snapshot snapshot: scoring setting card zero zero weight 1`
   <Form.Group>
     <Form.Control
       as="select"
-      floatingLabel="Grading Strategy"
-      onChange={[MockFunction scoringCardHooks.handleGradingStrategyChange]}
+      floatingLabel="Grading Method"
+      onChange={[MockFunction scoringCardHooks.handleGradingMethodChange]}
       value="last_score"
     >
       <option
@@ -281,9 +281,9 @@ exports[`ScoringCard snapshot snapshot: scoring setting card zero zero weight 1`
     </Form.Control>
     <Form.Control.Feedback>
       <FormattedMessage
-        defaultMessage="Define the grading strategy for this problem. By default, it is the score of the last submission made by the student."
-        description="Summary text for scoring grading strategy"
-        id="authoring.problemeditor.settings.scoring.gradingStrategy.hint"
+        defaultMessage="Define the grading method for this problem. By default, it is the score of the last submission made by the student."
+        description="Summary text for scoring grading method"
+        id="authoring.problemeditor.settings.scoring.gradingMethod.hint"
       />
     </Form.Control.Feedback>
   </Form.Group>

--- a/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.js
@@ -21,6 +21,7 @@ class ReactStateSettingsParser {
 
     settings = popuplateItem(settings, 'number', 'max_attempts', stateSettings.scoring.attempts, true);
     settings = popuplateItem(settings, 'weight', 'weight', stateSettings.scoring);
+    settings = popuplateItem(settings, 'gradingStrategy', 'grading_strategy', stateSettings.scoring);
     settings = popuplateItem(settings, 'on', 'showanswer', stateSettings.showAnswer);
     settings = popuplateItem(settings, 'afterAttempts', 'attempts_before_showanswer_button', stateSettings.showAnswer);
     settings = popuplateItem(settings, 'showResetButton', 'show_reset_button', stateSettings);

--- a/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.js
+++ b/src/editors/containers/ProblemEditor/data/ReactStateSettingsParser.js
@@ -21,7 +21,7 @@ class ReactStateSettingsParser {
 
     settings = popuplateItem(settings, 'number', 'max_attempts', stateSettings.scoring.attempts, true);
     settings = popuplateItem(settings, 'weight', 'weight', stateSettings.scoring);
-    settings = popuplateItem(settings, 'gradingStrategy', 'grading_strategy', stateSettings.scoring);
+    settings = popuplateItem(settings, 'gradingMethod', 'grading_method', stateSettings.scoring);
     settings = popuplateItem(settings, 'on', 'showanswer', stateSettings.showAnswer);
     settings = popuplateItem(settings, 'afterAttempts', 'attempts_before_showanswer_button', stateSettings.showAnswer);
     settings = popuplateItem(settings, 'showResetButton', 'show_reset_button', stateSettings);

--- a/src/editors/containers/ProblemEditor/data/SettingsParser.js
+++ b/src/editors/containers/ProblemEditor/data/SettingsParser.js
@@ -38,6 +38,8 @@ export const parseScoringSettings = (metadata, defaultSettings) => {
 
   scoring = popuplateItem(scoring, 'weight', 'weight', metadata);
 
+  scoring = popuplateItem(scoring, 'grading_strategy', 'gradingStrategy', metadata);
+
   return scoring;
 };
 

--- a/src/editors/containers/ProblemEditor/data/SettingsParser.js
+++ b/src/editors/containers/ProblemEditor/data/SettingsParser.js
@@ -38,7 +38,7 @@ export const parseScoringSettings = (metadata, defaultSettings) => {
 
   scoring = popuplateItem(scoring, 'weight', 'weight', metadata);
 
-  scoring = popuplateItem(scoring, 'grading_strategy', 'gradingStrategy', metadata);
+  scoring = popuplateItem(scoring, 'grading_method', 'gradingMethod', metadata);
 
   return scoring;
 };

--- a/src/editors/data/constants/problem.js
+++ b/src/editors/data/constants/problem.js
@@ -216,6 +216,32 @@ export const RandomizationTypes = StrictDict({
   },
 });
 
+export const GradingStrategyKeys = StrictDict({
+  LAST_ATTEMPT: 'last_attempt',
+  HIGHEST_GRADE: 'highest_attempt',
+  AVERAGE_GRADE: 'average_attempt',
+  FIRST_ATTEMPT: 'first_attempt',
+});
+
+export const GradingStrategy = StrictDict({
+  [GradingStrategyKeys.LAST_ATTEMPT]: {
+    id: 'authoring.problemeditor.settings.gradingstrategy.last_attempt',
+    defaultMessage: 'Last Attempt',
+  },
+  [GradingStrategyKeys.HIGHEST_GRADE]: {
+    id: 'authoring.problemeditor.settings.gradingstrategy.highest_grade',
+    defaultMessage: 'Highest Attempt',
+  },
+  [GradingStrategyKeys.AVERAGE_GRADE]: {
+    id: 'authoring.problemeditor.settings.gradingstrategy.average_grade',
+    defaultMessage: 'Average Attempt',
+  },
+  [GradingStrategyKeys.FIRST_ATTEMPT]: {
+    id: 'authoring.problemeditor.settings.gradingstrategy.first_attempt',
+    defaultMessage: 'First Attempt',
+  },
+});
+
 export const RichTextProblems = [ProblemTypeKeys.SINGLESELECT, ProblemTypeKeys.MULTISELECT];
 
 export const settingsOlxAttributes = [
@@ -226,4 +252,5 @@ export const settingsOlxAttributes = [
   '@_show_reset_button',
   '@_submission_wait_seconds',
   '@_attempts_before_showanswer_button',
+  '@_grading_strategy',
 ];

--- a/src/editors/data/constants/problem.js
+++ b/src/editors/data/constants/problem.js
@@ -216,28 +216,28 @@ export const RandomizationTypes = StrictDict({
   },
 });
 
-export const GradingStrategyKeys = StrictDict({
+export const GradingMethodKeys = StrictDict({
   LAST_SCORE: 'last_score',
   HIGHEST_SCORE: 'highest_score',
   AVERAGE_SCORE: 'average_score',
   FIRST_SCORE: 'first_score',
 });
 
-export const GradingStrategy = StrictDict({
-  [GradingStrategyKeys.LAST_SCORE]: {
-    id: 'authoring.problemeditor.settings.gradingstrategy.last_score',
+export const GradingMethod = StrictDict({
+  [GradingMethodKeys.LAST_SCORE]: {
+    id: 'authoring.problemeditor.settings.gradingmethod.last_score',
     defaultMessage: 'Last Score',
   },
-  [GradingStrategyKeys.HIGHEST_SCORE]: {
-    id: 'authoring.problemeditor.settings.gradingstrategy.highest_score',
+  [GradingMethodKeys.HIGHEST_SCORE]: {
+    id: 'authoring.problemeditor.settings.gradingmethod.highest_score',
     defaultMessage: 'Highest Score',
   },
-  [GradingStrategyKeys.AVERAGE_SCORE]: {
-    id: 'authoring.problemeditor.settings.gradingstrategy.average_score',
+  [GradingMethodKeys.AVERAGE_SCORE]: {
+    id: 'authoring.problemeditor.settings.gradingmethod.average_score',
     defaultMessage: 'Average Score',
   },
-  [GradingStrategyKeys.FIRST_SCORE]: {
-    id: 'authoring.problemeditor.settings.gradingstrategy.first_score',
+  [GradingMethodKeys.FIRST_SCORE]: {
+    id: 'authoring.problemeditor.settings.gradingmethod.first_score',
     defaultMessage: 'First Score',
   },
 });
@@ -252,5 +252,5 @@ export const settingsOlxAttributes = [
   '@_show_reset_button',
   '@_submission_wait_seconds',
   '@_attempts_before_showanswer_button',
-  '@_grading_strategy',
+  '@_grading_method',
 ];

--- a/src/editors/data/constants/problem.js
+++ b/src/editors/data/constants/problem.js
@@ -217,28 +217,28 @@ export const RandomizationTypes = StrictDict({
 });
 
 export const GradingStrategyKeys = StrictDict({
-  LAST_ATTEMPT: 'last_attempt',
-  HIGHEST_GRADE: 'highest_attempt',
-  AVERAGE_GRADE: 'average_attempt',
-  FIRST_ATTEMPT: 'first_attempt',
+  LAST_SCORE: 'last_score',
+  HIGHEST_SCORE: 'highest_score',
+  AVERAGE_SCORE: 'average_score',
+  FIRST_SCORE: 'first_score',
 });
 
 export const GradingStrategy = StrictDict({
-  [GradingStrategyKeys.LAST_ATTEMPT]: {
-    id: 'authoring.problemeditor.settings.gradingstrategy.last_attempt',
-    defaultMessage: 'Last Attempt',
+  [GradingStrategyKeys.LAST_SCORE]: {
+    id: 'authoring.problemeditor.settings.gradingstrategy.last_score',
+    defaultMessage: 'Last Score',
   },
-  [GradingStrategyKeys.HIGHEST_GRADE]: {
-    id: 'authoring.problemeditor.settings.gradingstrategy.highest_grade',
-    defaultMessage: 'Highest Attempt',
+  [GradingStrategyKeys.HIGHEST_SCORE]: {
+    id: 'authoring.problemeditor.settings.gradingstrategy.highest_score',
+    defaultMessage: 'Highest Score',
   },
-  [GradingStrategyKeys.AVERAGE_GRADE]: {
-    id: 'authoring.problemeditor.settings.gradingstrategy.average_grade',
-    defaultMessage: 'Average Attempt',
+  [GradingStrategyKeys.AVERAGE_SCORE]: {
+    id: 'authoring.problemeditor.settings.gradingstrategy.average_score',
+    defaultMessage: 'Average Score',
   },
-  [GradingStrategyKeys.FIRST_ATTEMPT]: {
-    id: 'authoring.problemeditor.settings.gradingstrategy.first_attempt',
-    defaultMessage: 'First Attempt',
+  [GradingStrategyKeys.FIRST_SCORE]: {
+    id: 'authoring.problemeditor.settings.gradingstrategy.first_score',
+    defaultMessage: 'First Score',
   },
 });
 

--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -24,7 +24,7 @@ const initialState = {
         unlimited: false,
         number: null,
       },
-      gradingStrategy: GradingStrategyKeys.LAST_ATTEMPT,
+      gradingStrategy: GradingStrategyKeys.LAST_SCORE,
     },
     hints: [],
     timeBetween: 0,

--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -2,7 +2,7 @@ import _ from 'lodash-es';
 import { createSlice } from '@reduxjs/toolkit';
 import { indexToLetterMap } from '../../../containers/ProblemEditor/data/OLXParser';
 import { StrictDict } from '../../../utils';
-import { ProblemTypeKeys, RichTextProblems } from '../../constants/problem';
+import { GradingStrategyKeys, ProblemTypeKeys, RichTextProblems } from '../../constants/problem';
 import { ToleranceTypes } from '../../../containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Tolerance/constants';
 
 const nextAlphaId = (lastId) => String.fromCharCode(lastId.charCodeAt(0) + 1);
@@ -24,6 +24,7 @@ const initialState = {
         unlimited: false,
         number: null,
       },
+      gradingStrategy: GradingStrategyKeys.LAST_ATTEMPT,
     },
     hints: [],
     timeBetween: 0,

--- a/src/editors/data/redux/problem/reducers.js
+++ b/src/editors/data/redux/problem/reducers.js
@@ -2,7 +2,7 @@ import _ from 'lodash-es';
 import { createSlice } from '@reduxjs/toolkit';
 import { indexToLetterMap } from '../../../containers/ProblemEditor/data/OLXParser';
 import { StrictDict } from '../../../utils';
-import { GradingStrategyKeys, ProblemTypeKeys, RichTextProblems } from '../../constants/problem';
+import { GradingMethodKeys, ProblemTypeKeys, RichTextProblems } from '../../constants/problem';
 import { ToleranceTypes } from '../../../containers/ProblemEditor/components/EditProblemView/SettingsWidget/settingsComponents/Tolerance/constants';
 
 const nextAlphaId = (lastId) => String.fromCharCode(lastId.charCodeAt(0) + 1);
@@ -24,7 +24,7 @@ const initialState = {
         unlimited: false,
         number: null,
       },
-      gradingStrategy: GradingStrategyKeys.LAST_SCORE,
+      gradingMethod: GradingMethodKeys.LAST_SCORE,
     },
     hints: [],
     timeBetween: 0,


### PR DESCRIPTION
## Description
This PR adds a new field in the Problem Editor for choosing a **Grading Strategy**. Currently, the only Grading Strategy is the Last Score. From now on, the new grading strategies are:

1. **Last Score _(Default)_**: The last score made is taken for grading.
2. **First Score**: The first score made is taken for grading.
3. **Highest Score**: The highest score made is taken for grading.
4. **Average Score**: The average of all scores made is taken for grading.

## Screenshots
![image](https://github.com/eduNEXT/frontend-lib-content-components/assets/64033729/c4c09b35-bd2d-40ec-a2fd-2fe9b3d9f29a)
![image](https://github.com/eduNEXT/frontend-lib-content-components/assets/64033729/5ffbaa67-552c-4644-bf8d-d0f83e18eabe)
![image](https://github.com/eduNEXT/frontend-lib-content-components/assets/64033729/9e6ba85d-e59f-4585-b99b-b50b5161f855)

## Dependencies
This PR needs the changes made from [this PR](https://github.com/eduNEXT/edx-platform/pull/299), which includes the new field from the Backend.

## Testing Instructions

Using `tutor` you can test these changes:

1. In your tutor environment clone the [frontend-app-course-authoring MFE](https://github.com/openedx/frontend-app-course-authoring/)
2. Create a mount with `tutor mounts add frontend-app-course-authoring`
3. Run `tutor config save` and `tutor dev start -d`
4. Inside the `frontend-app-course-authoring` folder clone this repository and checkout to this branch.
6. Inside the `frontend-app-course-authoring` folder create a new file called `module.config.js` with this content:

    ```javascript
    module.exports = {
      localModules: [
        {
          moduleName: "@edx/frontend-lib-content-components/dist",
          dir: "./frontend-lib-content-components",
          dist: "src",
        },
        {
          moduleName: "@edx/frontend-lib-content-components",
          dir: "./frontend-lib-content-components",
          dist: "src",
        },
      ],
    };
    ``` 
7. Then run `npm install`. First in `frontend-lib-content-components`, then in `frontend-app-course-authoring`.
8. Active in the Django admin (`admin/waffle/flag/`) this waffle flags: `new_core_editors.use_new_problem_editor` and `new_core_editors.use_new_text_editor` like this:

    ![image](https://github.com/eduNEXT/frontend-lib-content-components/assets/64033729/c0d986a1-5b95-46ac-936c-e7317688dbce)
9. Go to Studio and create a new component with a problem, for example: **Single select**
10. In the settings of the component you should see the new field.
